### PR TITLE
Fixed clock in wrong position

### DIFF
--- a/roles/local.proaluno/files/dconf-dump.ini
+++ b/roles/local.proaluno/files/dconf-dump.ini
@@ -131,9 +131,9 @@ object-type='applet'
 applet-iid='NotificationAreaAppletFactory::NotificationArea'
 locked=true
 toplevel-id='bottom'
-position=916
+position=1
 object-type='applet'
-panel-right-stick=false
+panel-right-stick=true
 
 [org/mate/panel/objects/show-desktop]
 applet-iid='WnckletFactory::ShowDesktopApplet'
@@ -154,9 +154,9 @@ panel-right-stick=false
 applet-iid='ClockAppletFactory::ClockApplet'
 locked=true
 toplevel-id='bottom'
-position=978
+position=0
 object-type='applet'
-panel-right-stick=false
+panel-right-stick=true
 
 [org/mate/panel/objects/object-2/prefs]
 show-temperature=false
@@ -169,9 +169,9 @@ show-weather=false
 [org/mate/panel/objects/object-3]
 locked=true
 toplevel-id='bottom'
-position=136
+position=1
 object-type='separator'
-panel-right-stick=false
+panel-right-stick=true
 
 [org/mate/mate-menu/plugins/applications]
 last-active-tab=0


### PR DESCRIPTION
This commits fixes the issue where the clock and notifications bar are displayed in incorrect locations when the screen is horizontally bigger than 1024x768.