### PR TITLE
Add timer to logout user after two hours

### DIFF
--- a/roles/local.proaluno/files/countdown.desktop
+++ b/roles/local.proaluno/files/countdown.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Exec="/proaluno/countdown.sh"
+Hidden=false
+X-MATE-Autostart-enabled=yes
+Name=Countdown
+Comment=Logout user after two hours

--- a/roles/local.proaluno/files/countdown.sh
+++ b/roles/local.proaluno/files/countdown.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+MAX_LOGON_TIME=120
+ALERT_WHEN_REMAINING=5
+
+ME=`basename "$0"`
+
+cleanup()
+{
+    for pid in `pgrep $ME`; do
+        if [ $pid -ne $$ ]; then
+            kill $pid
+        fi
+    done
+}
+
+alert()
+{
+    gdialog --print-maxsize --msgbox \
+    "Seu tempo está acabando, lembre-se que seus dados são apagados no logout!"
+}
+
+do_logout()
+{
+    pkill -KILL -u $(whoami)
+}
+
+main()
+{
+    local sleep_until=$(expr $MAX_LOGON_TIME - $ALERT_WHEN_REMAINING)
+
+    cleanup
+    sleep "${sleep_until}m"
+    alert &
+    sleep "${ALERT_WHEN_REMAINING}m"
+    do_logout
+}
+
+main

--- a/roles/local.proaluno/tasks/mate.yml
+++ b/roles/local.proaluno/tasks/mate.yml
@@ -56,3 +56,21 @@
     src: files/10dconf_override
     dest: /etc/X11/Xsession.d/10dconf_override
     mode: '0644'
+
+- name: Copy countdown.sh
+  copy:
+    src: files/countdown.sh
+    dest: /proaluno/countdown.sh
+    mode: '0755'
+
+- name: create /etc/share/mate/autostart folder
+  file:
+    path: /etc/share/mate/autostart
+    state: directory
+    mode: '0755'
+
+- name: Copy countdown.desktop
+  copy:
+    src: files/countdown.desktop
+    dest: /etc/share/mate/autostart/countdown.desktop
+    mode: '0755'


### PR DESCRIPTION
This commit adds a script that automatically warns and logout the user after two hours, killing all user applications.

Please keep in mind that I could not test the ansible part as I am still unable to run the infrastructure, altrough I have tested the script myself in a VM.

Closes #41 #31 #51 