### PR TITLE
remove workspace switcher

### DIFF
--- a/roles/local.proaluno/files/dconf-dump.ini
+++ b/roles/local.proaluno/files/dconf-dump.ini
@@ -84,7 +84,7 @@ computer-icon-visible=true
 trash-icon-visible=true
 
 [org/mate/panel/general]
-object-id-list=['notification-area', 'show-desktop', 'window-list', 'workspace-switcher', 'object-1', 'object-2', 'object-3', 'object-4', 'object-6', 'object-5']
+object-id-list=['notification-area', 'show-desktop', 'window-list', 'object-1', 'object-2', 'object-3', 'object-4', 'object-6', 'object-5']
 toplevel-id-list=['bottom']
 
 [org/mate/panel/toplevels/bottom]
@@ -100,14 +100,6 @@ toplevel-id='bottom'
 position=3
 object-type='separator'
 panel-right-stick=true
-
-[org/mate/panel/objects/workspace-switcher]
-applet-iid='WnckletFactory::WorkspaceSwitcherApplet'
-locked=true
-toplevel-id='bottom'
-position=146
-object-type='applet'
-panel-right-stick=false
 
 [org/mate/panel/objects/object-5]
 applet-iid='MateMenuAppletFactory::MateMenuApplet'
@@ -129,7 +121,7 @@ panel-right-stick=false
 applet-iid='WnckletFactory::WindowListApplet'
 locked=true
 toplevel-id='bottom'
-position=277
+position=146
 object-type='applet'
 
 [org/mate/panel/objects/notification-area]


### PR DESCRIPTION
Isso remove os 4 quadrados no canto da tela, o workspace-switcher, e ajusta as distancias da taskbar de acordo. Testamos numa VM, melhor checar no vagrant pra ver se tb funciona.