### PR TITLE
Fix duplex e outras opções de impressão

### DIFF
--- a/roles/local.proaluno/files/ppds/K7600_direto_duplex.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_direto_duplex.ppd
@@ -39,8 +39,8 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT<0D0A>"
 *JCLEnd: "<1B>%-12345X"
 
-*cupsFilter2: "application/vnd.cups-pdf application/prs.usp-samsung-pdf 10 -"
-*cupsFilter2: "image/urf image/prs.usp-samsung-raster 0 -"
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
+*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/ppds/K7600_direto_duplex_borda_menor.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_direto_duplex_borda_menor.ppd
@@ -39,8 +39,8 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT<0D0A>"
 *JCLEnd: "<1B>%-12345X"
 
-*cupsFilter2: "application/vnd.cups-pdf application/prs.usp-samsung-pdf 10 -"
-*cupsFilter2: "image/urf image/prs.usp-samsung-raster 0 -"
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
+*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/ppds/K7600_direto_simplex.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_direto_simplex.ppd
@@ -39,8 +39,8 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT<0D0A>"
 *JCLEnd: "<1B>%-12345X"
 
-*cupsFilter2: "application/vnd.cups-pdf application/prs.usp-samsung-pdf 10 -"
-*cupsFilter2: "image/urf image/prs.usp-samsung-raster 0 -"
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
+*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/ppds/K7600_processado_duplex.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_processado_duplex.ppd
@@ -40,8 +40,8 @@
 *JCLEnd: "<1B>%-12345X"
 
 *cupsPreFilter: "application/pdf 100 gstopdf17"
-*cupsFilter2: "application/vnd.cups-pdf application/prs.usp-samsung-pdf 10 -"
-*cupsFilter2: "image/urf image/prs.usp-samsung-raster 0 -"
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
+*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/ppds/K7600_processado_duplex_borda_menor.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_processado_duplex_borda_menor.ppd
@@ -40,8 +40,8 @@
 *JCLEnd: "<1B>%-12345X"
 
 *cupsPreFilter: "application/pdf 100 gstopdf17"
-*cupsFilter2: "application/vnd.cups-pdf application/prs.usp-samsung-pdf 10 -"
-*cupsFilter2: "image/urf image/prs.usp-samsung-raster 0 -"
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
+*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/ppds/K7600_processado_simplex.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_processado_simplex.ppd
@@ -40,8 +40,8 @@
 *JCLEnd: "<1B>%-12345X"
 
 *cupsPreFilter: "application/pdf 100 gstopdf17"
-*cupsFilter2: "application/vnd.cups-pdf application/prs.usp-samsung-pdf 10 -"
-*cupsFilter2: "image/urf image/prs.usp-samsung-raster 0 -"
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
+*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/usp.types
+++ b/roles/local.proaluno/files/usp.types
@@ -2,8 +2,3 @@
 # para serem enviados para a impressora Samsung linha K7600
 application/oxps
 application/vnd.ms-xpsdocument
-
-# Arquivos ja processados por alguma instancia do CUPS prontos
-# para serem enviados para a impressora Samsung linha K7600
-application/prs.usp-samsung-pdf
-image/prs.usp-samsung-raster


### PR DESCRIPTION
Com isto, as opções de impressão referentes a duplex (simplex, long-edge, short-edge) e outras raramente usadas devem passar a  funcionar. Nos PPDs do servidor as linhas que mencionam application/prs.usp-samsung-pdf e application/prs.usp-samsung-raster devem ser eliminadas também, assim como as entradas correspondentes de usp.types. O que deve permanecer é

*cupsFilter2: "application/vnd.cups-pdf application/pdf 10 -"
*cupsFilter2: "application/vnd.cups-raster image/urf 50 rastertopwg"

No futuro, será preciso ver o que acontece com os tipos mime do windows.