### PR TITLE
Limpa fila de impressão na reinicialização

### DIFF
--- a/roles/local.proaluno/files/limpa_fila_impressao.sh
+++ b/roles/local.proaluno/files/limpa_fila_impressao.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Esse script requer bash!
+
+if [ -z $BASH ]; then
+    echo "limpa_fila_impressao.sh: Esse script requer bash."
+    exit 1
+fi
+
+# Pega todas as impressoras na máquina.
+get_all_printers()
+{
+    lpstat -a | awk '{ print $1 }'
+}
+
+# Mata todos os jobs na máquina.
+kill_all_jobs()
+{
+
+    all_printers=$(get_all_printers)
+
+    for printer in $all_printers; do
+        lpstat -o $printer | while read job; do
+            jobnum=$(echo $job | cut -f1 -d" "| cut -f2 -d-)
+            echo "Removendo job $jobnum na impressora $printer..."
+            lprm -P $printer $jobnum
+        done
+    done
+}
+
+kill_all_jobs

--- a/roles/local.proaluno/tasks/proaluno_init.yml
+++ b/roles/local.proaluno/tasks/proaluno_init.yml
@@ -9,3 +9,15 @@
     name: "a job for reboot"
     special_time: reboot
     job: "/proaluno/limpa_homes.sh"
+
+- name: Copy limpa_fila_impressao.sh
+  copy:
+    src: files/limpa_fila_impressao.sh
+    dest: /proaluno/limpa_fila_impressao.sh
+    mode: '0755'
+
+- name: proaluno_init.sh script
+  cron:
+    name: "a job for reboot"
+    special_time: reboot
+    job: "/proaluno/limpa_fila_impressao.sh"


### PR DESCRIPTION
Esse script limpa a fila de impressão durante a reinicialização do
sistema cliente.

Nota: Não funciona se o ansible rodar esse job depois da morte do
CUPS

Relacionado a: #77 #74 