### PR TITLE
Conversão para PDF 1.4 ao invés de 1.7

### DIFF
--- a/roles/local.proaluno/files/gstopdf14
+++ b/roles/local.proaluno/files/gstopdf14
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# gstopdf14 - Ghostscript-based PDF filter for CUPS
+#
+# (C) 2019 Nelson Lago <lago@ime.usp.br>
+# Based on gstopdf from OpenPrinting cups-filters package,
+# (C) 2012 Till Kamppeter <till.kamppeter@gmail.com>
+#
+# Released under GPL 2 or later
+#
+# gstopdf uses gstoraster which, in turn, uses GhostScript
+# with the -dCompatibilityLevel=1.3 option. In this script,
+# we directly call GhostScript with the same options as
+# gstoraster, except for the -dCompatibilityLevel=1.4 option.
+
+echo "DEBUG: gstopdf14 argv[$#] = $@" >&2
+echo "DEBUG: PPD: $PPD" >&2
+
+if [ $# -lt 5 -o $# -gt 6 ]; then
+    echo "ERROR: gstopdf14 job-id user title copies options [file]" >&2
+    exit 1
+fi
+
+# Read from given file.
+if [ -n "$6" ]; then
+    exec <"$6"
+fi
+
+/usr/bin/gs -dQUIET -dPARANOIDSAFER -dNOPAUSE -dBATCH -dNOINTERPOLATE \
+            -dNOMEDIAATTRS -dShowAcroForm -sstdout=%stderr -sOutputFile=%stdout \
+            -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
+            -dAutoRotatePages=/None -dAutoFilterColorImages=false -dNOPLATFONTS \
+            -dColorImageFilter=/FlateEncode -dPDFSETTINGS=/printer \
+            -dColorConversionStrategy=/LeaveColorUnchanged - 2>/dev/null

--- a/roles/local.proaluno/files/ppds/K7600_processado.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_processado.ppd
@@ -39,7 +39,7 @@
 *JCLToPSInterpreter: "@PJL ENTER LANGUAGE = POSTSCRIPT<0D0A>"
 *JCLEnd: "<1B>%-12345X"
 
-*cupsPreFilter: "application/pdf 100 gstopdf17"
+*cupsPreFilter: "application/pdf 100 gstopdf14"
 *cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
 *cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 


### PR DESCRIPTION
Aparentemente, a impressora está travando com alguns arquivos PDF. O ideal seria levantar pelo menos um exemplo de arquivo que causa esse problema para testes, mas também podemos simplesmente tentar enviar arquivos PDF 1.4 ao invés de 1.7 para ela.

Signed-off-by: Nelson Lago <lago@ime.usp.br>