### PR TITLE
Remove raster para evitar problemas improváveis

### DIFF
--- a/roles/local.proaluno/files/ppds/K7600_direto.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_direto.ppd
@@ -40,7 +40,6 @@
 *JCLEnd: "<1B>%-12345X"
 
 *cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
-*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options

--- a/roles/local.proaluno/files/ppds/K7600_processado.ppd
+++ b/roles/local.proaluno/files/ppds/K7600_processado.ppd
@@ -41,7 +41,6 @@
 
 *cupsPreFilter: "application/pdf 100 gstopdf17"
 *cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pdf 10 -"
-*cupsFilter2: "application/vnd.cups-raster application/vnd.cups-raster 0 -"
 
 *% =========================================================
 *% Installable Options


### PR DESCRIPTION
Quando não houver mais nada para fazer, esse PR faz uma mudança que na prática não deve mudar nada :)

CUPS só envia os atributos IPP (como sides) se o arquivo
é application/pdf, application/vnd.cups-pdf ou image/*
(https://github.com/apple/cups/issues/2349). Como
precisamos dos atributos IPP para que o duplex funcione
corretamente, vamos eliminar do PPD a linha que permite
o envio de arquivos não-pdf para a impressora.

Signed-off-by: Nelson Lago <lago@ime.usp.br>