### PR TITLE
Aumenta o tempo de vida do cupsd

### DIFF
--- a/roles/local.proaluno/templates/cupsd.conf
+++ b/roles/local.proaluno/templates/cupsd.conf
@@ -11,6 +11,8 @@ Listen /run/cups/cups.sock
 Browsing Off
 BrowseLocalProtocols dnssd
 
+IdleExitTimeout 1300 # Um pouco maior que MaxJobTime
+
 # Preservar Jobs por 7 dias
 # Supondo que o job é 187285, ele estará na pasta:
 # /var/spool/cups/d187285-001


### PR DESCRIPTION
cupsd deixa de executar após um certo tempo ocioso. Vamos fazer
esse tempo ser maior que MaxJobTime para garantir que jobs
problemáticos sejam sempre eliminados.