### PR TITLE
Volta MaxJobs de 5 para 500

### DIFF
--- a/roles/local.proaluno/templates/cupsd.conf
+++ b/roles/local.proaluno/templates/cupsd.conf
@@ -21,8 +21,13 @@ DefaultAuthType Basic
 
 WebInterface Yes
 
-# Até quantos jobs são processados simutaneamente
-MaxJobs 5
+# Até quantos jobs são processados simultaneamente
+# O default é 500; reduzir parece uma boa ideia,
+# mas talvez cause cancelamentos de novos trabalhos
+# ou outros eventos inesperados. MaxJobTime é
+# provavelmente uma solução melhor para controlar
+# o número de jobs.
+#MaxJobs 5
 
 # Cancelar jobs e não tentar reenvia-los para fila
 ErrorPolicy abort-job


### PR DESCRIPTION
Não sei se limitar MaxJobs é uma boa ideia, a pensar melhor.

Se o número de jobs atinge o máximo, qual o comportamento do cups? Ele provavelmente vai impedir a entrada de novos jobs na fila, gerando um erro de impressão para o usuário. Provavelmente é melhor limitar o número de jobs garantindo que MaxJobTime funcione corretamente.